### PR TITLE
Add Action for Terragrunt wrapper

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -66,6 +66,6 @@ runs:
     ${{ inputs.plan-json-log-file != '' && format('-l {0}', inputs.plan-json-log-file) || '' }}
     ${{ inputs.apply-log-file != '' && format('-f {0}', inputs.apply-log-file) || '' }}
     ${{ inputs.workspace != '' && format('-w {0}', inputs.workspace) || '' }}
-    ${{ inputs.environment != '' && format('-e {0}', inputs.environment) || '' }}
+    ${{ inputs.environment != '' && format('--environment {0}', inputs.environment) || '' }}
     ${{ inputs.terragrunt-version != '' && format('--terragrunt-version {0}', inputs.terragrunt-version) || '' }}
     ${{ inputs.args }}

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Workspace identifier'
     required: true
     default: ''
+  environment:
+    description: 'Environment identifier'
+    required: false
+    default: ''
+  terragrunt-version:
+    description: 'Terragrunt version used to run the plan/apply'
+    required: false
+    default: ''
   args:
     description: 'Additional arguments for the fireflyci executed command'
     default: ''
@@ -58,4 +66,6 @@ runs:
     ${{ inputs.plan-json-log-file != '' && format('-l {0}', inputs.plan-json-log-file) || '' }}
     ${{ inputs.apply-log-file != '' && format('-f {0}', inputs.apply-log-file) || '' }}
     ${{ inputs.workspace != '' && format('-w {0}', inputs.workspace) || '' }}
+    ${{ inputs.environment != '' && format('-e {0}', inputs.environment) || '' }}
+    ${{ inputs.terragrunt-version != '' && format('--terragrunt-version {0}', inputs.terragrunt-version) || '' }}
     ${{ inputs.args }}

--- a/terragrunt/action.yml
+++ b/terragrunt/action.yml
@@ -43,13 +43,15 @@ runs:
         
         if [ -z "$REAL_TERRAFORM" ]; then
           echo "::warning::Terraform binary not found in PATH. Wrapper will be installed but may not work until terraform is installed."
+          REAL_TERRAFORM_PATH=""
         else
           echo "Found terraform at: $REAL_TERRAFORM"
           
           # Move real terraform to a backup location
           REAL_DIR=$(dirname "$REAL_TERRAFORM")
           sudo mv "$REAL_TERRAFORM" "$REAL_DIR/terraform.real"
-          echo "Moved real terraform to: $REAL_DIR/terraform.real"
+          REAL_TERRAFORM_PATH="$REAL_DIR/terraform.real"
+          echo "Moved real terraform to: $REAL_TERRAFORM_PATH"
         fi
         
         # Create a terraform wrapper script that calls our IaC wrapper with absolute path
@@ -57,6 +59,7 @@ runs:
         #!/bin/sh
         # Terraform wrapper that uses the IaC wrapper script
         export IAC_BINARY="terraform"
+        export IAC_BINARY_PATH="$REAL_TERRAFORM_PATH"
         exec "$WRAPPER_SCRIPT" "\$@"
         EOF
         
@@ -82,13 +85,15 @@ runs:
         
         if [ -z "$REAL_TOFU" ]; then
           echo "::warning::Tofu binary not found in PATH. Wrapper will be installed but may not work until tofu is installed."
+          REAL_TOFU_PATH=""
         else
           echo "Found tofu at: $REAL_TOFU"
           
           # Move real tofu to a backup location
           REAL_DIR=$(dirname "$REAL_TOFU")
           sudo mv "$REAL_TOFU" "$REAL_DIR/tofu.real"
-          echo "Moved real tofu to: $REAL_DIR/tofu.real"
+          REAL_TOFU_PATH="$REAL_DIR/tofu.real"
+          echo "Moved real tofu to: $REAL_TOFU_PATH"
         fi
         
         # Create a tofu wrapper script that calls our IaC wrapper with absolute path
@@ -96,6 +101,7 @@ runs:
         #!/bin/sh
         # Tofu wrapper that uses the IaC wrapper script
         export IAC_BINARY="tofu"
+        export IAC_BINARY_PATH="$REAL_TOFU_PATH"
         exec "$WRAPPER_SCRIPT" "\$@"
         EOF
         

--- a/terragrunt/action.yml
+++ b/terragrunt/action.yml
@@ -36,6 +36,7 @@ runs:
       shell: bash
       run: |
         WRAPPER_DIR="${{ inputs.wrapper-dir }}"
+        WRAPPER_SCRIPT="$WRAPPER_DIR/iac-wrapper.sh"
         
         # Find the real terraform binary
         REAL_TERRAFORM=$(which terraform 2>/dev/null || echo "")
@@ -51,13 +52,12 @@ runs:
           echo "Moved real terraform to: $REAL_DIR/terraform.real"
         fi
         
-        # Create a terraform wrapper script that calls our IaC wrapper
-        cat > "$WRAPPER_DIR/terraform" << 'EOF'
+        # Create a terraform wrapper script that calls our IaC wrapper with absolute path
+        cat > "$WRAPPER_DIR/terraform" << EOF
         #!/bin/sh
         # Terraform wrapper that uses the IaC wrapper script
         export IAC_BINARY="terraform"
-        SCRIPT_DIR=$(dirname "$0")
-        exec "$SCRIPT_DIR/iac-wrapper.sh" "$@"
+        exec "$WRAPPER_SCRIPT" "\$@"
         EOF
         
         chmod +x "$WRAPPER_DIR/terraform"
@@ -75,6 +75,7 @@ runs:
       shell: bash
       run: |
         WRAPPER_DIR="${{ inputs.wrapper-dir }}"
+        WRAPPER_SCRIPT="$WRAPPER_DIR/iac-wrapper.sh"
         
         # Find the real tofu binary
         REAL_TOFU=$(which tofu 2>/dev/null || echo "")
@@ -90,13 +91,12 @@ runs:
           echo "Moved real tofu to: $REAL_DIR/tofu.real"
         fi
         
-        # Create a tofu wrapper script that calls our IaC wrapper
-        cat > "$WRAPPER_DIR/tofu" << 'EOF'
+        # Create a tofu wrapper script that calls our IaC wrapper with absolute path
+        cat > "$WRAPPER_DIR/tofu" << EOF
         #!/bin/sh
         # Tofu wrapper that uses the IaC wrapper script
         export IAC_BINARY="tofu"
-        SCRIPT_DIR=$(dirname "$0")
-        exec "$SCRIPT_DIR/iac-wrapper.sh" "$@"
+        exec "$WRAPPER_SCRIPT" "\$@"
         EOF
         
         chmod +x "$WRAPPER_DIR/tofu"

--- a/terragrunt/action.yml
+++ b/terragrunt/action.yml
@@ -1,0 +1,142 @@
+name: 'Terragrunt IaC Wrapper'
+
+description: 'Installs a wrapper script to intercept and log terraform/tofu commands when invoked by Terragrunt'
+
+inputs:
+  iac-binary:
+    description: 'Which IaC binary to wrap: terraform, tofu, or both'
+    required: false
+    default: 'terraform'
+  wrapper-dir:
+    description: 'Directory to install the wrapper script (will be added to PATH)'
+    required: false
+    default: '/usr/local/bin/iac-wrapper'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Setup wrapper directory
+      shell: bash
+      run: |
+        echo "Setting up IaC wrapper for ${{ inputs.iac-binary }}"
+        
+        # Create wrapper directory if it doesn't exist
+        WRAPPER_DIR="${{ inputs.wrapper-dir }}"
+        mkdir -p "$WRAPPER_DIR"
+        
+        # Copy the wrapper script to the wrapper directory
+        SCRIPT_DIR="${{ github.action_path }}/scripts"
+        cp "$SCRIPT_DIR/iac-wrapper.sh" "$WRAPPER_DIR/iac-wrapper.sh"
+        chmod +x "$WRAPPER_DIR/iac-wrapper.sh"
+        
+        echo "Wrapper script installed at: $WRAPPER_DIR/iac-wrapper.sh"
+    
+    - name: Setup Terraform wrapper
+      if: inputs.iac-binary == 'terraform' || inputs.iac-binary == 'both'
+      shell: bash
+      run: |
+        WRAPPER_DIR="${{ inputs.wrapper-dir }}"
+        
+        # Find the real terraform binary
+        REAL_TERRAFORM=$(which terraform 2>/dev/null || echo "")
+        
+        if [ -z "$REAL_TERRAFORM" ]; then
+          echo "::warning::Terraform binary not found in PATH. Wrapper will be installed but may not work until terraform is installed."
+        else
+          echo "Found terraform at: $REAL_TERRAFORM"
+          
+          # Move real terraform to a backup location
+          REAL_DIR=$(dirname "$REAL_TERRAFORM")
+          sudo mv "$REAL_TERRAFORM" "$REAL_DIR/terraform.real"
+          echo "Moved real terraform to: $REAL_DIR/terraform.real"
+        fi
+        
+        # Create a terraform wrapper script that calls our IaC wrapper
+        cat > "$WRAPPER_DIR/terraform" << 'EOF'
+        #!/bin/sh
+        # Terraform wrapper that uses the IaC wrapper script
+        export IAC_BINARY="terraform"
+        SCRIPT_DIR=$(dirname "$0")
+        exec "$SCRIPT_DIR/iac-wrapper.sh" "$@"
+        EOF
+        
+        chmod +x "$WRAPPER_DIR/terraform"
+        
+        # Create symlink in the original location if terraform was found
+        if [ -n "$REAL_TERRAFORM" ]; then
+          sudo ln -sf "$WRAPPER_DIR/terraform" "$REAL_TERRAFORM"
+          echo "Created wrapper symlink at: $REAL_TERRAFORM"
+        fi
+        
+        echo "Terraform wrapper installed"
+    
+    - name: Setup Tofu wrapper
+      if: inputs.iac-binary == 'tofu' || inputs.iac-binary == 'both'
+      shell: bash
+      run: |
+        WRAPPER_DIR="${{ inputs.wrapper-dir }}"
+        
+        # Find the real tofu binary
+        REAL_TOFU=$(which tofu 2>/dev/null || echo "")
+        
+        if [ -z "$REAL_TOFU" ]; then
+          echo "::warning::Tofu binary not found in PATH. Wrapper will be installed but may not work until tofu is installed."
+        else
+          echo "Found tofu at: $REAL_TOFU"
+          
+          # Move real tofu to a backup location
+          REAL_DIR=$(dirname "$REAL_TOFU")
+          sudo mv "$REAL_TOFU" "$REAL_DIR/tofu.real"
+          echo "Moved real tofu to: $REAL_DIR/tofu.real"
+        fi
+        
+        # Create a tofu wrapper script that calls our IaC wrapper
+        cat > "$WRAPPER_DIR/tofu" << 'EOF'
+        #!/bin/sh
+        # Tofu wrapper that uses the IaC wrapper script
+        export IAC_BINARY="tofu"
+        SCRIPT_DIR=$(dirname "$0")
+        exec "$SCRIPT_DIR/iac-wrapper.sh" "$@"
+        EOF
+        
+        chmod +x "$WRAPPER_DIR/tofu"
+        
+        # Create symlink in the original location if tofu was found
+        if [ -n "$REAL_TOFU" ]; then
+          sudo ln -sf "$WRAPPER_DIR/tofu" "$REAL_TOFU"
+          echo "Created wrapper symlink at: $REAL_TOFU"
+        fi
+        
+        echo "Tofu wrapper installed"
+    
+    - name: Verify installation
+      shell: bash
+      run: |
+        echo "Verifying wrapper installation..."
+        
+        if [ "${{ inputs.iac-binary }}" = "terraform" ] || [ "${{ inputs.iac-binary }}" = "both" ]; then
+          if command -v terraform >/dev/null 2>&1; then
+            echo "✓ Terraform wrapper is accessible"
+            echo "  Location: $(which terraform)"
+          else
+            echo "::warning::Terraform wrapper not found in PATH"
+          fi
+        fi
+        
+        if [ "${{ inputs.iac-binary }}" = "tofu" ] || [ "${{ inputs.iac-binary }}" = "both" ]; then
+          if command -v tofu >/dev/null 2>&1; then
+            echo "✓ Tofu wrapper is accessible"
+            echo "  Location: $(which tofu)"
+          else
+            echo "::warning::Tofu wrapper not found in PATH"
+          fi
+        fi
+        
+        echo ""
+        echo "Wrapper installation complete!"
+        echo "Terragrunt will now use the wrapper script to capture logs for plan, apply, destroy, and init commands."
+
+branding:
+  icon: 'box'
+  color: 'blue'
+

--- a/terragrunt/scripts/iac-wrapper.sh
+++ b/terragrunt/scripts/iac-wrapper.sh
@@ -10,8 +10,18 @@ set -e
 BINARY_NAME="${IAC_BINARY:-terraform}"  # Default to terraform if not set
 
 # Path to the actual IaC binary
-# Use which to find the actual binary, or fall back to common locations
-if [ -x "/bin/${BINARY_NAME}" ]; then
+# First check if IAC_BINARY_PATH is set (used when wrapper is installed)
+if [ -n "$IAC_BINARY_PATH" ] && [ -x "$IAC_BINARY_PATH" ]; then
+  IAC_BIN="$IAC_BINARY_PATH"
+# Otherwise try to find the .real version (in case wrapper was installed)
+elif [ -x "/bin/${BINARY_NAME}.real" ]; then
+  IAC_BIN="/bin/${BINARY_NAME}.real"
+elif [ -x "/usr/bin/${BINARY_NAME}.real" ]; then
+  IAC_BIN="/usr/bin/${BINARY_NAME}.real"
+elif [ -x "/usr/local/bin/${BINARY_NAME}.real" ]; then
+  IAC_BIN="/usr/local/bin/${BINARY_NAME}.real"
+# Fall back to finding the regular binary
+elif [ -x "/bin/${BINARY_NAME}" ]; then
   IAC_BIN="/bin/${BINARY_NAME}"
 elif [ -x "/usr/bin/${BINARY_NAME}" ]; then
   IAC_BIN="/usr/bin/${BINARY_NAME}"

--- a/terragrunt/scripts/iac-wrapper.sh
+++ b/terragrunt/scripts/iac-wrapper.sh
@@ -1,0 +1,239 @@
+#!/bin/sh
+# IaC wrapper script for capturing individual module logs when invoked by terragrunt
+# This script intercepts terraform/tofu commands and ensures proper log capture per subfolder
+# The IAC_BINARY environment variable determines which binary to use (terraform or tofu)
+# POSIX-compliant for use in minimal containers
+
+set -e
+
+# Determine which binary to use from environment variable
+BINARY_NAME="${IAC_BINARY:-terraform}"  # Default to terraform if not set
+
+# Path to the actual IaC binary
+# Use which to find the actual binary, or fall back to common locations
+if [ -x "/bin/${BINARY_NAME}" ]; then
+  IAC_BIN="/bin/${BINARY_NAME}"
+elif [ -x "/usr/bin/${BINARY_NAME}" ]; then
+  IAC_BIN="/usr/bin/${BINARY_NAME}"
+elif [ -x "/usr/local/bin/${BINARY_NAME}" ]; then
+  IAC_BIN="/usr/local/bin/${BINARY_NAME}"
+else
+  # Try to find it using which
+  IAC_BIN=$(which "${BINARY_NAME}" 2>/dev/null || echo "${BINARY_NAME}")
+fi
+
+# Get the command (first argument)
+COMMAND="$1"
+
+# Filter out the standalone '-' separator that Terragrunt v0.67+ might pass
+# This is used by Terragrunt to separate its flags from Terraform flags
+# We need to rebuild the argument list without the '-' separator
+# Use a POSIX-compliant approach with positional parameters
+shift # Remove the command from $@
+NEWARGS=""
+FIRST=1
+for arg in "$@"; do
+  if [ "$arg" != "-" ]; then
+    if [ "$FIRST" -eq 1 ]; then
+      NEWARGS="$arg"
+      FIRST=0
+    else
+      NEWARGS="$NEWARGS $arg"
+    fi
+  fi
+done
+
+# Rebuild positional parameters with command + filtered args
+# shellcheck disable=SC2086
+set -- "$COMMAND" $NEWARGS
+
+# Find the module directory (where terragrunt.hcl is located)
+# Terragrunt runs IaC from .terragrunt-cache, but we want logs in the module dir
+MODULE_DIR=""
+if [ -n "$TERRAGRUNT_WORKING_DIR" ]; then
+  MODULE_DIR="$TERRAGRUNT_WORKING_DIR"
+else
+  # Try to find the parent directory that contains terragrunt.hcl
+  CURRENT_DIR="$PWD"
+  while [ "$CURRENT_DIR" != "/" ]; do
+    if [ -f "$CURRENT_DIR/../terragrunt.hcl" ]; then
+      MODULE_DIR="$CURRENT_DIR/.."
+      break
+    fi
+    CURRENT_DIR=$(dirname "$CURRENT_DIR")
+  done
+fi
+
+# If we couldn't find module dir, use current directory
+if [ -z "$MODULE_DIR" ]; then
+  MODULE_DIR="$PWD"
+fi
+
+# Execute IaC and capture logs based on the command
+case "$COMMAND" in
+  "plan")
+    # Check if -json flag is present and -out flag is present
+    HAS_JSON=false
+    OUT_FILE=""
+    PREV_ARG=""
+    
+    for arg in "$@"; do
+      if [ "$arg" = "-json" ]; then
+        HAS_JSON=true
+      fi
+      # Handle -out=filename format
+      case "$arg" in
+        -out=*)
+          OUT_FILE="${arg#-out=}"
+          ;;
+      esac
+      # Handle -out filename format (filename is in next arg)
+      if [ "$PREV_ARG" = "-out" ]; then
+        OUT_FILE="$arg"
+      fi
+      PREV_ARG="$arg"
+    done
+    
+    # If this is a plan with -json and -out, capture to plan_log.jsonl
+    if [ "$HAS_JSON" = true ] && [ -n "$OUT_FILE" ]; then
+      # Run plan and redirect output to plan_log.jsonl in the module directory
+      # Use a temporary file to capture exit code (POSIX-compliant)
+      EXITCODE_FILE="/tmp/wrapper_exitcode_$$"
+      
+      # Ensure MODULE_DIR is set and log file path is valid
+      if [ -z "$MODULE_DIR" ]; then
+        MODULE_DIR="$PWD"
+      fi
+      
+      # Run terraform and capture output, ignoring tee errors
+      { "$IAC_BIN" "$@" 2>&1; echo $? > "$EXITCODE_FILE"; } | tee "$MODULE_DIR/plan_log.jsonl" || true
+      EXIT_CODE=$(cat "$EXITCODE_FILE")
+      rm -f "$EXITCODE_FILE"
+      
+      # If plan succeeded and created a plan file, generate additional outputs
+      # The plan file is in the current working directory (.terragrunt-cache)
+      if [ $EXIT_CODE -eq 0 ]; then
+        # Wait a moment for file system sync
+        sleep 0.1
+        
+        if [ -f "$OUT_FILE" ]; then
+          # Copy plan file to module directory
+          cp "$OUT_FILE" "$MODULE_DIR/$OUT_FILE" 2>/dev/null
+          
+          # Generate plan_output.json (JSON format) - critical file
+          # Use TF_CLI_ARGS= to prevent globally set CLI arguments from affecting show
+          if TF_CLI_ARGS= "$IAC_BIN" show -json "$OUT_FILE" > "$MODULE_DIR/plan_output.json" 2>/dev/null; then
+            : # Success
+          else
+            # If show fails, try with the copied plan file
+            TF_CLI_ARGS= "$IAC_BIN" show -json "$MODULE_DIR/$OUT_FILE" > "$MODULE_DIR/plan_output.json" 2>/dev/null || \
+              echo "{\"error\": \"Failed to generate plan output\"}" > "$MODULE_DIR/plan_output.json"
+          fi
+          
+          # Generate plan_output_raw.log (human-readable format)
+          # Use TF_CLI_ARGS= to prevent globally set CLI arguments from affecting show
+          if ! TF_CLI_ARGS= "$IAC_BIN" show "$OUT_FILE" > "$MODULE_DIR/plan_output_raw.log" 2>/dev/null; then
+            TF_CLI_ARGS= "$IAC_BIN" show "$MODULE_DIR/$OUT_FILE" > "$MODULE_DIR/plan_output_raw.log" 2>/dev/null || \
+              echo "Failed to generate raw plan output" > "$MODULE_DIR/plan_output_raw.log"
+          fi
+        else
+          # Plan file not found, create placeholder files
+          echo "{\"error\": \"Plan file not found\"}" > "$MODULE_DIR/plan_output.json"
+          echo "Plan file $OUT_FILE not found" > "$MODULE_DIR/plan_output_raw.log"
+        fi
+      fi
+      
+      exit $EXIT_CODE
+    else
+      # Regular plan command
+      "$IAC_BIN" "$@"
+    fi
+    ;;
+    
+  "apply")
+    # Check if -json flag is present
+    HAS_JSON=false
+    for arg in "$@"; do
+      if [ "$arg" = "-json" ]; then
+        HAS_JSON=true
+        break
+      fi
+    done
+    
+    if [ "$HAS_JSON" = true ]; then
+      # Capture JSON output to apply_log.jsonl in the module directory
+      # Use a temporary file to capture exit code (POSIX-compliant)
+      EXITCODE_FILE="/tmp/wrapper_exitcode_$$"
+      
+      # Ensure MODULE_DIR is set
+      if [ -z "$MODULE_DIR" ]; then
+        MODULE_DIR="$PWD"
+      fi
+      
+      { "$IAC_BIN" "$@" 2>&1; echo $? > "$EXITCODE_FILE"; } | tee "$MODULE_DIR/apply_log.jsonl" || true
+      EXIT_CODE=$(cat "$EXITCODE_FILE")
+      rm -f "$EXITCODE_FILE"
+      exit $EXIT_CODE
+    else
+      "$IAC_BIN" "$@"
+    fi
+    ;;
+    
+  "destroy")
+    # Check if -json flag is present
+    HAS_JSON=false
+    for arg in "$@"; do
+      if [ "$arg" = "-json" ]; then
+        HAS_JSON=true
+        break
+      fi
+    done
+    
+    if [ "$HAS_JSON" = true ]; then
+      # Capture JSON output to destroy_log.jsonl in the module directory
+      # Use a temporary file to capture exit code (POSIX-compliant)
+      EXITCODE_FILE="/tmp/wrapper_exitcode_$$"
+      
+      # Ensure MODULE_DIR is set
+      if [ -z "$MODULE_DIR" ]; then
+        MODULE_DIR="$PWD"
+      fi
+      
+      { "$IAC_BIN" "$@" 2>&1; echo $? > "$EXITCODE_FILE"; } | tee "$MODULE_DIR/destroy_log.jsonl" || true
+      EXIT_CODE=$(cat "$EXITCODE_FILE")
+      rm -f "$EXITCODE_FILE"
+      exit $EXIT_CODE
+    else
+      "$IAC_BIN" "$@"
+    fi
+    ;;
+    
+  "init")
+    # Capture init output in the module directory
+    # Use a temporary file to capture exit code (POSIX-compliant)
+    EXITCODE_FILE="/tmp/wrapper_exitcode_$$"
+    
+    # Ensure MODULE_DIR is set
+    if [ -z "$MODULE_DIR" ]; then
+      MODULE_DIR="$PWD"
+    fi
+    
+    { "$IAC_BIN" "$@" 2>&1; echo $? > "$EXITCODE_FILE"; } | tee "$MODULE_DIR/init_log.jsonl" || true
+    EXIT_CODE=$(cat "$EXITCODE_FILE")
+    rm -f "$EXITCODE_FILE"
+    exit $EXIT_CODE
+    ;;
+    
+  "show")
+    # Show command with TF_CLI_ARGS= to prevent globally set CLI arguments from affecting show
+    # This matches the behavior in opentofu client.go
+    TF_CLI_ARGS= "$IAC_BIN" "$@"
+    ;;
+    
+  *)
+    # For all other commands, just execute the IaC binary
+    "$IAC_BIN" "$@"
+    ;;
+esac
+
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a composite action and script to wrap terraform/tofu under Terragrunt for per-module logging, and adds environment and terragrunt-version inputs to the FireflyCI action.
> 
> - **Terragrunt**:
>   - **New composite action** in `terragrunt/action.yml` to install an IaC wrapper for `terraform`/`tofu`, relocating real binaries to `*.real`, creating wrapper shims, and verifying availability.
>   - **Wrapper script** `terragrunt/scripts/iac-wrapper.sh` intercepts `plan/apply/destroy/init/show`, filters `-` separators, detects module dir, logs JSONL outputs (`plan_log.jsonl`, `apply_log.jsonl`, `destroy_log.jsonl`, `init_log.jsonl`) to the module, and generates `plan_output.json` and `plan_output_raw.log` when plan has `-json` and `-out`.
> - **FireflyCI action (`action.yml`)**:
>   - Adds inputs `environment` and `terragrunt-version` and forwards them as `--environment` and `--terragrunt-version` flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4eceb51864340e8478ffac454f077f4df53eadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->