### PR TITLE
Bump Firefly-CLI version to v0.5.160

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.153'
+  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.159'
   entrypoint: '/bin/sh'
   args:
   - '-c'

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.159'
+  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.160'
   entrypoint: '/bin/sh'
   args:
   - '-c'


### PR DESCRIPTION
Update Github Actions to use v0.5.160 of the Firefly-cli.
This update contains:
- Bug fixes and minor improvements
- Multi-environment execution support (for Terragrunt)