### PR TITLE
Bump Firefly-CLI version to v0.5.161

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.160'
+  image: 'docker://public.ecr.aws/firefly/fireflyci:v0.5.161'
   entrypoint: '/bin/sh'
   args:
   - '-c'


### PR DESCRIPTION
Bump Firefly-CLI version to v0.5.161
This update includes:
- Minor fix for image release